### PR TITLE
add all required props to vimeo iframe allow attribute - fixes #2151

### DIFF
--- a/src/js/plugins/vimeo.js
+++ b/src/js/plugins/vimeo.js
@@ -104,7 +104,7 @@ const vimeo = {
     const src = format(player.config.urls.vimeo.iframe, id, params);
     iframe.setAttribute('src', src);
     iframe.setAttribute('allowfullscreen', '');
-    iframe.setAttribute('allow', ['autoplay', 'fullscreen', 'picture-in-picture'].join('; '));
+    iframe.setAttribute('allow', ['autoplay', 'fullscreen', 'picture-in-picture', 'encrypted-media', 'accelerometer', 'gyroscope'].join('; '));
 
     // Set the referrer policy if required
     if (!is.empty(referrerPolicy)) {


### PR DESCRIPTION
### Link to related issue (if applicable)

https://github.com/sampotts/plyr/issues/2151

### Summary of proposed changes

Add same allow props than the ones used on the [Vimeo player demo website](https://player.vimeo.com/api/demo). 